### PR TITLE
remove BOM

### DIFF
--- a/sprite/pale.json
+++ b/sprite/pale.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "unknown" : {"width":24,"height":24, "x":0,"y":0,"pixelRatio":1,"visible":true},
 "国道番号" : {"width":64,"height":64, "x":0,"y":256,"pixelRatio":1,"visible":true},
 "指示点" : {"width":64,"height":64, "x":64,"y":256,"pixelRatio":1,"visible":true},

--- a/sprite/pale@2x.json
+++ b/sprite/pale@2x.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "unknown" : {"width":24,"height":24, "x":0,"y":0,"pixelRatio":1,"visible":true},
 "国道番号" : {"width":64,"height":64, "x":0,"y":256,"pixelRatio":1,"visible":true},
 "指示点" : {"width":64,"height":64, "x":64,"y":256,"pixelRatio":1,"visible":true},

--- a/sprite/std.json
+++ b/sprite/std.json
@@ -1,4 +1,4 @@
-﻿{
+{
 "unknown" : {"width":24,"height":24, "x":0,"y":0,"pixelRatio":1,"visible":true},
 "国道番号" : {"width":64,"height":64, "x":0,"y":256,"pixelRatio":1,"visible":true},
 "指示点" : {"width":64,"height":64, "x":64,"y":256,"pixelRatio":1,"visible":true},

--- a/sprite/std@2x.json
+++ b/sprite/std@2x.json
@@ -1,4 +1,4 @@
-﻿{
+{
 "unknown" : {"width":24,"height":24, "x":0,"y":0,"pixelRatio":1,"visible":true},
 "国道番号" : {"width":64,"height":64, "x":0,"y":256,"pixelRatio":1,"visible":true},
 "指示点" : {"width":64,"height":64, "x":64,"y":256,"pixelRatio":1,"visible":true},


### PR DESCRIPTION
sprite の各種 json ファイルの文字コードが UTF-8 なのですが BOM がついていました。
Linux 環境で利用するのに、json parse エラーが出たりするため、恐れ入りますが BOM なしにしていただけませんでしょうか。

どうぞよろしくお願いいたします。